### PR TITLE
fix(gasLeftCall): add content-type and non-200 response catch

### DIFF
--- a/healthchecker.go
+++ b/healthchecker.go
@@ -105,7 +105,7 @@ func (h *RPCHealthchecker) checkGasLimit(ctx context.Context) (uint64, error) {
 	rpcProviderGasLimit.WithLabelValues(h.config.Name).Set(float64(gasLimit))
 	zap.L().Debug("fetched gas limit", zap.Uint64("gasLimit", gasLimit), zap.String("rpcProvider", h.config.Name))
 	if err != nil {
-		zap.L().Error("failed fetching the gas limit", zap.Error(err), zap.String("rpcProvider", h.config.Name))
+		zap.L().Warn("failed fetching the gas limit", zap.Error(err), zap.String("rpcProvider", h.config.Name))
 		return gasLimit, err
 	}
 


### PR DESCRIPTION
When testing the rpc-gateway with Avalanche RPC: `https://api.avax.network/ext/bc/C/rpc`

The healthchecker constantly spits out:
```json
{"level":"error","ts":1646180571.727167,"caller":"src/healthchecker.go:108","msg":"failed fetching the gas limit","error":"invalid character 'i' looking for beginning of value","rpcProvider":"OfficialRPC","stacktrace":"main.(*RPCHealthchecker).checkGasLimit\n\t/src/healthchecker.go:108\nmain.(*RPCHealthchecker).checkAndSetGasLeftHealth\n\t/src/healthchecker.go:145"}
```

This is because the Avalanche returns 405 response with this body:
```
invalid content type, only application/json is supported
```

This PR fixes 2 issues:
- Added header "Content-Type": "application/json" so Avalanche RPC (and potentially other RPC providers) won't complain
- Catch non-200 response from the gasLeftCall and pass the response body to the error so we can troubleshoot easier. Logs after adding the non-200 response catching
```json
{"level":"warn","ts":1646180619.036573,"caller":"rpc-gateway/healthchecker.go:108","msg":"failed fetching the gas limit","error":"got non-200 response, status: 415, body: invalid content type, only application/json is supported\n","rpcProvider":"Cloudflare"}
```