### PR TITLE
Prefer composition over global variables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,13 +73,6 @@ issues:
         - errcheck
         - ineffassign
     # TODO
-    # Metrics implementation needs a bit more love to get us with no global variables.
-    #
-    - path: metrics.go
-      linters:
-        - gochecknoglobals
-        - gochecknoinits
-    # TODO
     # The key name should be embeded into a struct.
     - path: http_reverse_proxy.go
       linters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,4 @@ services:
     restart: always
     ports:
       - "8474:8474"
+      - "9991:9991"

--- a/healthcheck_manager_test.go
+++ b/healthcheck_manager_test.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func TestHealthcheckManager(t *testing.T) {
-	t.Parallel()
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	manager := NewHealthcheckManager(HealthcheckManagerConfig{
 		Targets: []TargetConfig{
 			{
@@ -55,7 +58,8 @@ func TestHealthcheckManager(t *testing.T) {
 }
 
 func TestHealthcheckManagerRollingWindowTaintEnabled(t *testing.T) {
-	t.Parallel()
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	manager := NewHealthcheckManager(HealthcheckManagerConfig{
 		Targets: []TargetConfig{
 			{
@@ -108,7 +112,8 @@ func TestHealthcheckManagerRollingWindowTaintEnabled(t *testing.T) {
 }
 
 func TestHealthcheckManagerRollingWindowTaintDisabled(t *testing.T) {
-	t.Parallel()
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	manager := NewHealthcheckManager(HealthcheckManagerConfig{
 		Targets: []TargetConfig{
 			{

--- a/http_failover_proxy_test.go
+++ b/http_failover_proxy_test.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 func createTestRpcGatewayConfig() RPCGatewayConfig {
@@ -34,6 +36,8 @@ func createTestRpcGatewayConfig() RPCGatewayConfig {
 }
 
 func TestHttpFailoverProxyRerouteRequests(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	fakeRpc1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Bad Request", http.StatusInternalServerError)
 	}))
@@ -98,6 +102,8 @@ func TestHttpFailoverProxyRerouteRequests(t *testing.T) {
 }
 
 func TestHttpFailoverProxyNotRerouteRequests(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	fakeRpc1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Service not available", http.StatusServiceUnavailable)
 	}))
@@ -156,6 +162,8 @@ func TestHttpFailoverProxyNotRerouteRequests(t *testing.T) {
 }
 
 func TestHttpFailoverProxyDecompressRequest(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	var receivedBody, receivedHeaderContentEncoding, receivedHeaderContentLength string
 	fakeRpc1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedHeaderContentEncoding = r.Header.Get("Content-Encoding")
@@ -224,6 +232,8 @@ func TestHttpFailoverProxyDecompressRequest(t *testing.T) {
 }
 
 func TestHttpFailoverProxyWithCompressionSupportedTarget(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	var receivedHeaderContentEncoding string
 	var receivedBody []byte
 	fakeRpc1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -293,6 +303,8 @@ func TestHttpFailoverProxyWithCompressionSupportedTarget(t *testing.T) {
 }
 
 func TestHttpFailoverProxyNotObserveFailureWhenClientCanceledRequest(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	fakeRpc1Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		time.Sleep(100 * time.Millisecond) // The RPC Provider takes 100ms to reply
 		w.Write([]byte("OK"))

--- a/http_reverse_proxy.go
+++ b/http_reverse_proxy.go
@@ -28,7 +28,7 @@ func doProcessRequest(r *http.Request, config TargetConfig) error {
 	var err error
 
 	if r.Body == nil {
-		return errors.New("no request body")
+		return errors.New("no body")
 	}
 
 	// The standard library stores ContentLength as signed data type.

--- a/integration_test.go
+++ b/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	toxiproxy "github.com/Shopify/toxiproxy/client"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -60,6 +61,8 @@ type TestUrl struct {
 }
 
 func TestRpcGatewayFailover(t *testing.T) {
+	prometheus.DefaultRegisterer = prometheus.NewRegistry()
+
 	// initial setup
 	logger, _ := zap.NewDevelopment()
 	zap.ReplaceGlobals(logger)

--- a/metrics.go
+++ b/metrics.go
@@ -5,71 +5,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 )
-
-var (
-	requestBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10}
-
-	responseTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "zeroex_rpc_gateway_request_duration_seconds",
-		Help:    "Histogram of response time for Gateway in seconds",
-		Buckets: requestBuckets,
-	}, []string{"provider", "method"})
-
-	rpcProviderStatus = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "zeroex_rpc_gateway_provider_status",
-		Help: "Current status of a given provider by type. Type can be either healthy or tainted.",
-	}, []string{"provider", "type"})
-
-	rpcProviderBlockNumber = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "zeroex_rpc_gateway_provider_block_number",
-		Help: "Block number of a given provider",
-	}, []string{"provider"})
-
-	rpcProviderGasLimit = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "zeroex_rpc_gateway_provider_gasLimit_number",
-		Help: "Gas limit of a given provider",
-	}, []string{"provider"})
-
-	rpcProviderInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "zeroex_rpc_gateway_provider_info",
-		Help: "Gas limit of a given provider",
-	}, []string{"index", "provider"})
-
-	healthcheckResponseTimeHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "zeroex_rpc_gateway_healthcheck_response_duration_seconds",
-		Help:    "Histogram of response time for Gateway Healthchecker in seconds",
-		Buckets: requestBuckets,
-	}, []string{"provider", "method"})
-
-	requestsProcessed = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "zeroex_rpc_gateway_requests_total",
-		Help: "The total number of processed requests by gateway",
-	}, []string{"status_code"})
-
-	requestErrorsHandled = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "zeroex_rpc_gateway_request_errors_handled_total",
-		Help: "The total number of request errors handled by gateway",
-	}, []string{"provider", "type"})
-
-	responseStatus = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "zeroex_rpc_gateway_target_response_status_total",
-		Help: "Total number of responses with a statuscode label",
-	}, []string{"provider", "status_code"})
-)
-
-func init() {
-	prometheus.MustRegister(responseTimeHistogram)
-	prometheus.MustRegister(rpcProviderStatus)
-	prometheus.MustRegister(rpcProviderBlockNumber)
-	prometheus.MustRegister(rpcProviderGasLimit)
-	prometheus.MustRegister(rpcProviderInfo)
-	prometheus.MustRegister(healthcheckResponseTimeHistogram)
-}
 
 type MetricsServer struct {
 	server *http.Server


### PR DESCRIPTION
This code changes the way we interact with metrics. This code proposes removal of globally accessible metrics and instead, it does promotes composition where a metric is attached to concrete entity. 

This way, I can start moving code parts into dedicated namespaces. 

One of the common idiomatic Go's practices is to use composition as much as possible without having a need to access global state. This way, we can reduce locks and improve concurrency. 