### PR TITLE
Inaccurate data

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -39,8 +39,6 @@ func NewProxy(proxyConfig Config, healthCheckManager *HealthcheckManager) *Proxy
 				Name: "zeroex_rpc_gateway_request_duration_seconds",
 				Help: "Histogram of response time for Gateway in seconds",
 				Buckets: []float64{
-					.005,
-					.01,
 					.025,
 					.05,
 					.1,
@@ -50,6 +48,10 @@ func NewProxy(proxyConfig Config, healthCheckManager *HealthcheckManager) *Proxy
 					2.5,
 					5,
 					10,
+					15,
+					20,
+					25,
+					30,
 				},
 			}, []string{
 				"provider",


### PR DESCRIPTION
When a node provider experience an issue and the request takes more time, we may notice a latency hits upper limit on the graph even if it's not true. It happens because we do retries and with a wait time between retries that may exceed the histogram upper limit.