### PR TITLE
Do not use latest block as health check

### DIFF
--- a/pkg/proxy/healthchecker.go
+++ b/pkg/proxy/healthchecker.go
@@ -174,15 +174,17 @@ func (h *RPCHealthchecker) checkAndSetBlockNumberHealth() {
 	ctx, cancel := context.WithTimeout(ctx, h.config.Timeout)
 	defer cancel()
 
+	// TODO
+	//
+	// This should be moved to a different place, because it does not do a
+	// health checking but it provides additional context.
+
 	blockNumber, err := h.checkBlockNumber(ctx)
-	h.mu.Lock()
-	defer h.mu.Unlock()
 	if err != nil {
-		h.isHealthy = false
 		return
 	}
+
 	h.blockNumber = blockNumber
-	h.isHealthy = true
 }
 
 func (h *RPCHealthchecker) checkAndSetGasLeftHealth() {


### PR DESCRIPTION
Use of retrieval the latest block as health check may lead to unexpected results when a node provider experiences outage and implements caching (this call is easily cacheable and it changes every 12-15 seconds).