### PR TITLE
Hello http.TimeoutHandler

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/go-http-utils/headers"
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,7 +18,7 @@ import (
 func createConfig() Config {
 	return Config{
 		Proxy: ProxyConfig{
-			UpstreamTimeout: 0,
+			UpstreamTimeout: time.Second * 3,
 		},
 		HealthChecks: HealthCheckConfig{
 			Interval:         0,

--- a/internal/proxy/reverseproxy.go
+++ b/internal/proxy/reverseproxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func NewReverseProxy(targetConfig TargetConfig, config Config) (*httputil.ReverseProxy, error) {
+func NewReverseProxy(targetConfig TargetConfig) (*httputil.ReverseProxy, error) {
 	target, err := url.Parse(targetConfig.Connection.HTTP.URL)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot parse url")
@@ -42,7 +42,6 @@ func NewReverseProxy(targetConfig TargetConfig, config Config) (*httputil.Revers
 		IdleConnTimeout:       30 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		ResponseHeaderTimeout: config.Proxy.UpstreamTimeout,
 	}
 
 	conntrack.PreRegisterDialerMetrics(targetConfig.Name)


### PR DESCRIPTION
Prefer http.TimeoutHandler instead ResponseHeaderTimeout. This way, we can simplify the interface and stop use UpstreamTimeut upon ReverseProxy creation.