### PR TITLE
Stop use interface and more accurate naming

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,14 +3,22 @@ run:
 
 linters:
   enable:
+    - asciicheck
+    - bidichk
     - bodyclose
+    - containedctx
     - depguard
     - dogsled
     - dupl
+    - durationcheck
     - errcheck
+    - errname
     - errorlint
+    - exhaustive
     - exportloopref
+    - forcetypeassert
     - funlen
+    - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst
@@ -25,21 +33,30 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - ireturn
+    - maintidx
+    - makezero
     - misspell
     - nakedret
     - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
     - prealloc
+    - predeclared
     - revive
     - rowserrcheck
     - staticcheck
     - stylecheck
+    - tagliatelle
+    - tenv
+    - thelper
     - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-    - gochecknoglobals
 
 linters-settings:
   funlen:

--- a/cmd/rpcgateway/main.go
+++ b/cmd/rpcgateway/main.go
@@ -70,6 +70,7 @@ func main() {
 		if err != nil {
 			logger.Error("error when stopping rpc gateway", zap.Error(err))
 		}
+
 		return nil
 	})
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -15,6 +15,7 @@ type Server struct {
 
 func (s *Server) Start() error {
 	zap.L().Info("metrics server starting", zap.String("listenAddr", s.server.Addr))
+
 	return s.server.ListenAndServe()
 }
 

--- a/internal/proxy/healthchecker_test.go
+++ b/internal/proxy/healthchecker_test.go
@@ -22,7 +22,7 @@ func TestBasicHealthchecker(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	healtcheckConfig := RPCHealthcheckerConfig{
+	healtcheckConfig := HealthCheckerConfig{
 		URL:              env.GetDefault("RPC_GATEWAY_NODE_URL_1", "https://cloudflare-eth.com"),
 		Interval:         1 * time.Second,
 		Timeout:          2 * time.Second,
@@ -30,7 +30,7 @@ func TestBasicHealthchecker(t *testing.T) {
 		SuccessThreshold: 1,
 	}
 
-	healthchecker, err := NewHealthchecker(healtcheckConfig)
+	healthchecker, err := NewHealthChecker(healtcheckConfig)
 	assert.NoError(t, err)
 
 	healthchecker.Start(ctx)

--- a/internal/proxy/healthchecker_utils.go
+++ b/internal/proxy/healthchecker_utils.go
@@ -20,6 +20,7 @@ type JSONRPCResponse struct {
 
 func hexToUint(hexString string) (uint64, error) {
 	hexString = strings.ReplaceAll(hexString, "0x", "")
+
 	return strconv.ParseUint(hexString, 16, 64)
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,14 +14,14 @@ import (
 type Proxy struct {
 	config             Config
 	targets            []*NodeProvider
-	healthcheckManager *HealthcheckManager
+	healthcheckManager *HealthCheckManager
 
 	metricResponseTime   *prometheus.HistogramVec
 	metricRequestErrors  *prometheus.CounterVec
 	metricResponseStatus *prometheus.CounterVec
 }
 
-func NewProxy(proxyConfig Config, healthCheckManager *HealthcheckManager) *Proxy {
+func NewProxy(proxyConfig Config, healthCheckManager *HealthCheckManager) *Proxy {
 	proxy := &Proxy{
 		config:             proxyConfig,
 		healthcheckManager: healthCheckManager,

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -64,7 +64,7 @@ func TestHttpFailoverProxyRerouteRequests(t *testing.T) {
 			},
 		},
 	}
-	healthcheckManager := NewHealthcheckManager(HealthcheckManagerConfig{
+	healthcheckManager := NewHealthCheckManager(HealthCheckManagerConfig{
 		Targets: rpcGatewayConfig.Targets,
 		Config:  rpcGatewayConfig.HealthChecks,
 	})
@@ -115,7 +115,7 @@ func TestHttpFailoverProxyDecompressRequest(t *testing.T) {
 		},
 	}
 
-	healthcheckManager := NewHealthcheckManager(HealthcheckManagerConfig{
+	healthcheckManager := NewHealthCheckManager(HealthCheckManagerConfig{
 		Targets: rpcGatewayConfig.Targets,
 		Config:  rpcGatewayConfig.HealthChecks,
 	})
@@ -169,7 +169,7 @@ func TestHttpFailoverProxyWithCompressionSupportedTarget(t *testing.T) {
 		},
 	}
 
-	healthcheckManager := NewHealthcheckManager(HealthcheckManagerConfig{
+	healthcheckManager := NewHealthCheckManager(HealthCheckManagerConfig{
 		Targets: rpcGatewayConfig.Targets,
 		Config:  rpcGatewayConfig.HealthChecks,
 	})
@@ -233,7 +233,7 @@ func TestHTTPFailoverProxyWhenCannotConnectToPrimaryProvider(t *testing.T) {
 			},
 		},
 	}
-	healthcheckManager := NewHealthcheckManager(HealthcheckManagerConfig{
+	healthcheckManager := NewHealthCheckManager(HealthCheckManagerConfig{
 		Targets: rpcGatewayConfig.Targets,
 		Config:  rpcGatewayConfig.HealthChecks,
 	})

--- a/internal/rpcgateway/rpcgateway.go
+++ b/internal/rpcgateway/rpcgateway.go
@@ -21,7 +21,7 @@ import (
 type RPCGateway struct {
 	config             RPCGatewayConfig
 	httpFailoverProxy  *proxy.Proxy
-	healthcheckManager *proxy.HealthcheckManager
+	healthcheckManager *proxy.HealthCheckManager
 	server             *http.Server
 }
 
@@ -52,12 +52,13 @@ func (r *RPCGateway) Stop(ctx context.Context) error {
 	if err != nil {
 		zap.L().Error("healthcheck manager failed to stop gracefully", zap.Error(err))
 	}
+
 	return r.server.Close()
 }
 
 func NewRPCGateway(config RPCGatewayConfig) *RPCGateway {
-	healthcheckManager := proxy.NewHealthcheckManager(
-		proxy.HealthcheckManagerConfig{
+	healthcheckManager := proxy.NewHealthCheckManager(
+		proxy.HealthCheckManagerConfig{
 			Targets: config.Targets,
 			Config:  config.HealthChecks,
 		})


### PR DESCRIPTION
There's no reason for this code to use interface for a health check probes. What's more, returning an interface is wrong. We should pass interface, do not return it.